### PR TITLE
bugfix - storing triples into just one named graph

### DIFF
--- a/includes/EasyRdf_Sparql_Client.inc
+++ b/includes/EasyRdf_Sparql_Client.inc
@@ -1,0 +1,33 @@
+<?php
+
+class EasyRdf_Sparql_Client2 extends EasyRdf_Sparql_Client {
+
+	public function insert($data, $graphUri = null)
+	{
+	    $query = 'INSERT INTO ';
+	    if ($graphUri) {
+	        $query .= "GRAPH <$graphUri> {";
+	    }
+	    $query .= $this->convertToTriples($data);
+	    if ($graphUri) {
+	        $query .= "}";
+	    }
+	    return $this->request('query', $query);
+	}
+
+    public function clear($graphUri, $silent = false)
+    {
+        $query = "CLEAR";
+        if ($silent) {
+            $query .= " SILENT";
+        }
+        if (preg_match('/^all|named|default$/i', $graphUri)) {
+            $query .= " $graphUri";
+        } else {
+            $query .= " GRAPH <$graphUri>";
+        }
+	    return $this->request('query', $query);
+    }
+}
+
+

--- a/includes/SparqlUpdateIndexerService.inc
+++ b/includes/SparqlUpdateIndexerService.inc
@@ -17,9 +17,16 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
       '#type' => 'textfield',
       '#title' => t('SPARQL Update URI'),
       '#description' => t('Enter the URI of the SPARQL Update service.'),
-      '#default_value' => $this->options['sparql_update_uri'],
+      '#default_value' => isset($this->options['sparql_update_uri']) ? $this->options['sparql_update_uri'] : '',
       '#required' => TRUE,
     );
+    $form['named_graph_uri'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Named graph URI'),
+      '#description' => t('Enter the URI of Named Graph where triples will be grouped'),
+      '#default_value' => isset($this->options['named_graph_uri']) ? $this->options['named_graph_uri'] : '',
+      '#required' => TRUE,
+    );    
     return $form;
   }
 
@@ -29,6 +36,9 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
       form_error($form['sparql_update_uri'], 'Please enter a valid URL.');
     }
 
+    if (!filter_var($values['named_graph_uri'], FILTER_VALIDATE_URL)) {
+      form_error($form['named_graph_uri'], 'Please enter a valid URL.');
+    }
   }
 
   /**
@@ -133,7 +143,7 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
                 $graph->add($graph_uri, $property, $value);
               }
             }
-            $client->insert($graph, $resource . '.rdf');
+            $client->insert($graph, $this->options['named_graph_uri']);
           }
 
         }
@@ -167,10 +177,7 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
       try {
         if ($ids = 'all') {
           // delete all items.
-          $client = new EasyRdf_Sparql_Client(
-            $this->options['sparql_query_uri'],
-            $this->options['sparql_update_uri']
-          );
+          $client = new EasyRdf_Sparql_Client($this->options['sparql_update_uri']);
           $client->clear('ALL');
         }
         elseif (is_array($ids)) {

--- a/includes/SparqlUpdateIndexerService.inc
+++ b/includes/SparqlUpdateIndexerService.inc
@@ -132,7 +132,6 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
         // do something with $rdf->uri and $rdf->index.
         // The save method should throw an exception on failure.
         if (easyrdf()) {
-
           $resource = $rdf_model->uri;
           $client = new EasyRdf_Sparql_Client($this->options['sparql_update_uri']);
 
@@ -146,6 +145,9 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
             $client->insert($graph, $this->options['named_graph_uri']);
           }
 
+        }
+        else {
+          drupal_set_message(t('Please, install and configure installation directory for Easyrdf library'), 'error');
         }
       } catch (Exception $e) {
         watchdog_exception('sparql_update_indexer', $e);

--- a/includes/SparqlUpdateIndexerService.inc
+++ b/includes/SparqlUpdateIndexerService.inc
@@ -178,10 +178,10 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
         if ($ids = 'all') {
           // delete all items.
           $client = new EasyRdf_Sparql_Client($this->options['sparql_update_uri']);
-          $client->clear('ALL');
+          $client->clear($this->options['named_graph_uri'], true);
         }
         elseif (is_array($ids)) {
-          $store = new EasyRdf_GraphStore($this->options['update_uri']);
+          $store = new EasyRdf_GraphStore($this->options['sparql_update_uri']);
           foreach ($ids as $id) {
             $rdf_model = rdfx_get_rdf_model($index->item_type, $id);
             // delete one item.

--- a/includes/SparqlUpdateIndexerService.inc
+++ b/includes/SparqlUpdateIndexerService.inc
@@ -133,7 +133,7 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
         // The save method should throw an exception on failure.
         if (easyrdf()) {
           $resource = $rdf_model->uri;
-          $client = new EasyRdf_Sparql_Client($this->options['sparql_update_uri']);
+          $client = new EasyRdf_Sparql_Client2($this->options['sparql_update_uri']);
 
           foreach ($rdf_model->index as $graph_uri => $graph_data) {
             $graph = new EasyRdf_Graph($graph_uri);
@@ -179,7 +179,7 @@ class SparqlUpdateIndexerService extends SearchApiAbstractService {
       try {
         if ($ids = 'all') {
           // delete all items.
-          $client = new EasyRdf_Sparql_Client($this->options['sparql_update_uri']);
+          $client = new EasyRdf_Sparql_Client2($this->options['sparql_update_uri']);
           $client->clear($this->options['named_graph_uri'], true);
         }
         elseif (is_array($ids)) {

--- a/sparql_update_indexer.info
+++ b/sparql_update_indexer.info
@@ -10,3 +10,4 @@ core = 7.x
 version = 0.1
 
 files[] = includes/SparqlUpdateIndexerService.inc
+files[] = includes/EasyRdf_Sparql_Client.inc


### PR DESCRIPTION
This patch adds a texbox to indicate the named graph where you will store your RDF triples.
Also, it prevents to create a named graph for each triple you store. Now, it stores all RDF triples in the named graph you have previously indicated. It was tested in Virtuoso.
